### PR TITLE
fix: add z-index to header for proper stacking context

### DIFF
--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -4,7 +4,7 @@ import { navLinks } from "../constants"
 
 const Nav = () => {
     return (
-        <header className="padding-x py-8 absolute w-full">
+        <header className="padding-x py-8 absolute w-full z-50">
             <nav className="flex justify-between items-center">
                 <a href="/">
                     <img


### PR DESCRIPTION
This pull request includes a small change to the `Nav` component. The change adds a `z-50` class to the `<header>` element to ensure it has a higher stacking context.